### PR TITLE
Feature: It's All About The Record Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,35 +31,54 @@ The util also gets information about available SObjects and if the Salesforce Or
 | `SObjectUtil.orgUsesPersonAccounts();` | `Boolean`     | Returns true if the Salesforce Org uses Person Accounts.              |
 
 
+### Public Non-Static Functions
+| Function                                 | Expected Params                 | Return Type   | Description                                                                                                                                                                                                                     |
+|:-----------------------------------------|:--------------------------------|:--------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `createQueryStringForRelatedSObject();`  | `String`                        | `String`      | Creates a query string for lookup fields on the current object. e.g `Contact.Account`. If the field is a standard Salesforce field it should have 'Id' on the end, and if it is a custom field it should have '__c' on the end. |
+| `createQueryStringForRelatedSObjects();` | `Set<String>` or `List<String>` | `String`      | Same as above, but for getting for multiple lookups at once. See **Quick How To Use** for an example.                                                                                                                           |
+| `getDefaultRecordTypeId();`              | None                            | `Id`          | Returns the default record type Id for the User on the current SObject.                                                                                                                                                         |
+
 ### Public Variables
 
-| Name                  | Type                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|:----------------------|:------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| selectAllString       | `String`                                  | Contains a comma separated string with all available fields for the SObject. e.g "Id, Name, CreatedDate, CreatedById, ..." to achieve the equivalent of `SELECT * FROM SObject` in Salesforce.                                                                                                                                                                                                                                                                |
-| mapRecordTypeNameToId | `Map<String, Id>`                         | The Key (String) is the DeveloperName of the record type. The Value (Id) is the Salesforce Id value for that record type.                                                                                                                                                                                                                                                                                                                                     |
-| mapDevNameToType      | `Map<String, String>`                     | The Key (String) is the DeveloperName of a field on the SObject. The Value (String) is the data type of the field.                                                                                                                                                                                                                                                                                                                                            |
-| mapPicklistValues     | `Map<String, List<Schema.PicklistEntry>>` | The Key (String) is the DeveloperName of a picklist field on the SObject. The Value (List<PicklistEntry>) is a list of PicklistEntry records for the picklist. Which can be used to populate a picklist with available options. More information: <a href="https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_class_Schema_PicklistEntry.htm#apex_class_Schema_PicklistEntry" target="_blank">Salesforce: Schema.PicklistEntry</a> |
-| fieldsRequired        | `Set<String>`                             | A set of Strings which are the DeveloperNames of required fields on the SObject level. Doesn't take into account fields that are required on page layouts.                                                                                                                                                                                                                                                                                                    |
-| fieldsUnique          | `Set<String>`                             | A set of Strings which are the DeveloperNames of fields that need to be unique amongst all records for the SObject in Salesforce                                                                                                                                                                                                                                                                                                                              |
+| Name                    | Type                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+|:------------------------|:------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| selectAllString         | `String`                                  | Contains a comma separated string with all available fields on the object.  e.g "Id, Name, CreatedDate, CreatedById,..." to achieve the equivalent of `SELECT * FROM SObject` in Salesforce.                                                                                                                                                                                                                                                         |
+| mapRecordTypeNameToId   | `Map<String, Id>`                         | The Key (String) is the DeveloperName of the record type. The Value (Id) is the Salesforce Id value for that record type.                                                                                                                                                                                                                                                                                                                            |
+| mapDevNameToType        | `Map<String, String>`                     | The Key (String) is the DeveloperName of a field on the SObject. The Value (String) is the data type of the field.                                                                                                                                                                                                                                                                                                                                   |
+| mapPicklistValues       | `Map<String, List<Schema.PicklistEntry>>` | The Key (String) is the name of a picklist field on the SObject. The Value (List<PicklistEntry>) is a list of PicklistEntry records for the picklist. Which can be used to populate a picklist with available options. More information: <a href="https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_class_Schema_PicklistEntry.htm#apex_class_Schema_PicklistEntry" target="_blank">Salesforce: Schema.PicklistEntry</a> |
+| mapRelatedSObjectFields | `Map<String, Set<String>>`                | The Key (String) is the name of the SObject. The Values are the field names for all fields on that SObject.                                                                                                                                                                                                                                                                                                                                          |
 
 
 ## Quick How To Use
 
-Say we want to use Account as an example.  Remember the `__c` if using a custom SObject.
+** Inititalise **
 
-**Inititalise**
-
-``` java
-SObjectUtil accountUtil = new SObjectUtil('Account');
-```
+```SObjectUtil accountUtil = new SObjectUtil('Account');```
+```SObjectUtil customObjectUtil = new SObjectUtil('MyCustomObject__c');```
 
 
-**Field String**
+** Field String **
+For the main SObject that the util has been initiated with, this will return all fields for only that object:
+```String accountFields = accountUtil.selectAllString;```
 
-``` java
-String accountFields = accountUtil.selectAllString;
-List<Account> testAccounts = [SELECT :accountUtil.selectAllString FROM Account];
-List<Account> testAccounts = [SELECT :accountFields FROM Account];
+To get fields for all or specific objects that have Lookups or Master-Detail Lookups on this SObject:
+```String contactFieldsOnAccount = accountUtil.createQueryStringForRelatedSObject('ContactId');```
+```String customObjectFieldsOnAccount = accountUtil.createQueryStringForRelatedSObject('CustomObject__c');```
+
+You can group multiple objects at time in a Set or List
+```List<String> sobjs = new List<String>{'ContactId', 'CustomObject__c'};```
+```String queryString = accountUtil.createQueryStringForRelatedObjects(sobjs);```
+
+_Example_
+
+```Java
+SObjectUtil contractUtil = new SObjectUtil('Contract');
+Set<String> testSet = new Set<String>{'AccountId', 'CustoObj__c'};
+String queryString = '';
+queryString += 'SELECT ' + animalUtil.selectAllString + ',\n';
+queryString += animalUtil.createQueryStringForRelatedSObjects(testSet) + '\n';
+queryString += ' FROM Contract';
+List<SObject> theResults = Database.query(queryString);
 ```
 
 

--- a/classes/SObjectUtil.cls
+++ b/classes/SObjectUtil.cls
@@ -28,6 +28,7 @@ public with sharing class SObjectUtil {
 
     public class SObjectUtilException extends Exception{}
 
+    final private Set<String> ENUM_LOOKUPS = new Set<String>{'REFERENCE'};
     final private Set<String> ENUM_PICKLISTS = new Set<String>{'PICKLIST', 'MULTIPICKLIST'};
     //  Salesforce ENUM information: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_enum_Schema_DisplayType.htm
     final private Set<String> ENUM_FIELD_TYPES = new Set<String>{
@@ -36,40 +37,63 @@ public with sharing class SObjectUtil {
         'ENCRYPTEDSTRING', 'ID', 'INTEGER', 'LONG', 'MULTIPICKLIST', 'PERCENT',
         'PHONE', 'PICKLIST', 'REFERENCE', 'STRING', 'TEXTAREA', 'TIME', 'URL'
     };
+    public Map<String, Set<String>> evilObjectFieldNames = new Map<String, Set<String>>();
 
     private SObjectType theSObjectDescribe { get; private set; }
+    public Id recordTypeIdDefault { get; private set; }
+    public Id recordTypeIdMaster { get; private set; }
+    public Set<String> setLookupDevNames { get; set; }
     public String selectAllString { get; private set; }                 //  A comma separated string of all fields on the SObject. Intended to act as * for SOQL queries
-    public Set<String> fieldsUnique { get; private set; }               //  The DeveloperNames of unique fields on the SObject
     public Set<String> fieldsRequired { get; private set; }             //  The DeveloperNames of required fields on the SObject level
+    public Set<String> fieldsUnique { get; private set; }               //  The DeveloperNames of fields that need to be unique to create or update a record
     public Map<String, Id> mapRecordTypeNameToId { get; private set; }  //  Maps the DeveloperName of a record type to its Id
     public Map<String, String> mapDevNameToType { get; private set; }   //  Maps the DeveloperName of a field to its field type (See: ENUM_FIELD_TYPES)
     //  Schema.PicklistEntry function information: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_class_Schema_PicklistEntry.htm#apex_class_Schema_PicklistEntry
     public Map<String, List<Schema.PicklistEntry>> mapPicklistValues { get; private set; }  //  Maps the DeveloperName of a picklist or multipicklist to its PicklistEntry vales
+    public Map<String, Set<String>> mapLookupDevNameToFields { get; private set; }          //  Maps the DeveloperName of a lookup field to a Set of strings which are the DeveloperNames of fields on the related SObject (Not automatically populated)
+
+    public Map<String, Set<String>> mapRelatedSObjectFields { get; private set; }           //  Used for Lookups and MD-Lookups. Maps lookup field name to the set of fields on that object
+    public Map<String, String> mapFieldNameToSObjectType { get; private set; }              //  Maps the looup field name to the SObject
 
 
-    public SObjectUtil(String sObjectType) {
+    public SObjectUtil(String reqSObjectType) {
+        //  Some standard SObjects don't like certain fields to be queried
+        //  Will likely be added to over time. Is public in case fields are found
+        //  with an object and they can be added to the filter here
+        this.evilObjectFieldNames.put('Contract', new Set<String>{
+            'ShippingStreet', 'ShippingCity', 'ShippingState', 'ShippingPostalCode', 'ShippingCountry', 'ShippingLatitude', 
+            'ShippingLongitude', 'ShippingGeocodeAccuracy', 'ShippingAddress', 'Name'});
+    
+
+        //  Now back to normal
+        Map<String, Schema.SObjectType> mapOrgSchema = Schema.getGlobalDescribe();
         try {
-            this.theSObjectDescribe = Schema.getGlobalDescribe().get(sObjectType);
+            this.theSObjectDescribe = Schema.getGlobalDescribe().get(reqSObjectType);
         } catch (Exception e) {
             throw new SObjectUtilException('An error occurred: ' + e.getMessage());
         }
         if (this.theSObjectDescribe == null) {
             String errorString = '';
-            errorString += 'The SObject: "' + sObjectType + '" does not exist in this org. ';
+            errorString += 'The SObject: "' + reqSObjectType + '" does not exist in this org. ';
             errorString += 'If you are using a custom object, remember to add the __c at the end. ';
             throw new SObjectUtilException(errorString);
         }
 
-        this.fieldsUnique = new Set<String>();
-        this.fieldsRequired = new Set<String>();
-        this.mapDevNameToType = new Map<String, String>();
-        this.mapPicklistValues = new Map<String, List<Schema.PicklistEntry>>();
-
+        this.setLookupDevNames = new Set<String>();
+        this.fieldsUnique      = new Set<String>();
+        this.fieldsRequired    = new Set<String>();
+        this.mapDevNameToType          = new Map<String, String>();
+        this.mapPicklistValues         = new Map<String, List<Schema.PicklistEntry>>();
+        this.mapLookupDevNameToFields  = new Map<String, Set<String>>();
+        this.mapRelatedSObjectFields   = new Map<String, Set<String>>();
+        this.mapFieldNameToSObjectType = new Map<String, String>();
+        
+        //  Populate data for the main SObject
         try {
-            this.populateMapFieldInformation(sObjectType);
-            this.populateMapRecordTypes(sObjectType);
+            this.populateMapFieldInformation(reqSObjectType);
+            this.populateRecordTypeInformation(reqSObjectType);
         } catch (Exception e) {
-            throw new SOBjectUtilException('An error occurred: ' + e.getMessage());
+            throw new SOBjectUtilException('Could not set up data for SObject: ' + reqSObjectType + '. An error occurred: ' + e.getMessage());
         }
     }
 
@@ -79,12 +103,10 @@ public with sharing class SObjectUtil {
     /*  ****************************************  */
 
     /**
-     * Populates the public variables:
+     * Populates the public variables: 
      * - mapDevNameToType
-     * - fieldsUnique
-     * - fieldsRequired
-     * @param   String. API Name of the SObject to populate field
-     *          name and type inforation for.
+     * - requiredFields
+     * @param   String. API Name of the SObject to populate field name and type inforation for.
      */
     private void populateMapFieldInformation(String theSObjectType) {
         Map<String, Schema.SObjectField> mapAccFields = this.theSObjectDescribe.getDescribe().fields.getMap();
@@ -92,6 +114,11 @@ public with sharing class SObjectUtil {
         for (String fieldKey : mapAccFields.keySet()) {
             //  Populdate map of FieldName to FieldType
             String fieldName = mapAccFields.get(fieldKey).getDescribe().getName();
+
+            if (this.evilObjectFieldNames.containsKey(theSObjectType) && this.evilObjectFieldNames.get(theSObjectType).contains(fieldName)) {
+                continue;
+            }
+
             String fieldType = String.valueOf(mapAccFields.get(fieldKey).getDescribe().getType());
             this.mapDevNameToType.put(fieldName, fieldType);
 
@@ -109,6 +136,19 @@ public with sharing class SObjectUtil {
             if (this.ENUM_PICKLISTS.contains(fieldType.toUpperCase())) {
                 this.mapPicklistValues.put(fieldName, mapAccFields.get(fieldKey).getDescribe().getPicklistValues());
             }
+
+            //  Populate set of Lookup and Master-Detail fields on the SObject
+            if (this.ENUM_LOOKUPS.contains(fieldType.toUpperCase())) {
+                if (mapAccFields.get(fieldKey).getDescribe().isNamePointing()) {
+                    //  isNamePointing(): If getDescribe points to more than one object
+                    //  Example of this is the lookup can look to: User, Group
+                    for (Schema.SObjectType sot : mapAccFields.get(fieldKey).getDescribe().getReferenceTo()) {
+                        this.populateRelatedSObjectInformation(fieldName, sot);
+                    }
+                } else {
+                    this.populateRelatedSObjectInformation(fieldName, mapAccFields.get(fieldKey).getDescribe().getReferenceTo()[0]);
+                }
+            }
         }
 
         //  Populate select all string used for a wildcard SOQL selector query
@@ -117,30 +157,133 @@ public with sharing class SObjectUtil {
 
 
     /**
-     * Populates the public variable in the class: mapRecordTypeNameToId
-     * @param   String. API Name of the SObject to populate Record Type
-     *          information for.
+     * Populates the map of SObject Name to a set of field API names for each object the
+     * requested SObject has lookups for
+     * @param   Schema.SobjectType. The SObject to populate the fields for
      */
-    private void populateMapRecordTypes(String theSObjectType) {
-        this.mapRecordTypeNameToId = new Map<String, Id>();
+    private void populateRelatedSObjectInformation(String theFieldName, Schema.SObjectType theSObject) {
+        //  We don't want to know about RecordType
+        if (theFieldName == 'RecordTypeId') {
+            return;
+        }
 
-        for (RecordType rt : this.queryRecordTypes(theSObjectType)) {
-            this.mapRecordTypeNameToId.put(rt.DeveloperName, rt.Id);
+        //  Store map for fields, sobject name, and field name
+        String sObjectName = theSObject.getDescribe().getName();
+        this.mapFieldNameToSObjectType.put(theFieldName, sObjectName);
+        if (!this.mapRelatedSObjectFields.keySet().contains(sObjectName)) {
+            // System.debug('Populating related field information for: ' + sObjectName);
+            Set<String> flds = theSObject.getDescribe().fields.getMap().keySet();
+
+            //  Remove any nasty fields listed above so we don't run into any issues while querying
+            if (this.evilObjectFieldNames.containsKey(sObjectName)) {
+                for (String fd : flds) {
+                    if (this.evilObjectFieldNames.get(sObjectName).contains(fd)) {
+                        flds.remove(fd);
+                    }
+                }
+            }
+
+            this.mapRelatedSObjectFields.put(sObjectName, flds);
         }
     }
 
 
     /**
-     * Uses a SOQL query to get all record types for the given sobject
-     * @param   String. Name of the SObject to query record types for
-     * @return  List<RecordType>
+     * Uses the Schema class to get information about Record Types for the SObject. Also popultes
+     * Ids for the default record type Id for the user, and the master record type Id to fall back on
+     * @param   String. The name of the SObject
      */
-    private List<RecordType> queryRecordTypes(String theSObjectType) {
-        return [
-            SELECT Id, Name, DeveloperName, IsActive, SObjectType, Description
-            FROM RecordType
-            WHERE SObjectType = :theSObjectType
-        ];
+    private void populateRecordTypeInformation(String theSObjectType) {
+        this.mapRecordTypeNameToId = new Map<String, Id>();
+        Schema.DescribeSObjectResult sObjectResult = null;
+
+        try {
+            List<Schema.DescribeSObjectResult> tempSObjResults = Schema.describeSObjects(new List<String>{theSObjectType});
+            sObjectResult = tempSObjResults[0];
+        } catch (Exception e) {
+            System.debug('SObjectUtil: Could not populate record types using Schema for: ' + theSObjectType);
+            System.debug(e.getMessage());
+            return;
+        }
+
+        for (Schema.RecordTypeInfo rti : sObjectResult.getRecordTypeInfos()) {
+            //  Default record type for the user running the code
+            if (rti.isDefaultRecordTypeMapping()) {
+                this.recordTypeIdDefault = rti.getRecordTypeId();
+            }
+            //  Default record type for the SObject. Used as a fall back
+            if (rti.isMaster()) {
+                this.recordTypeIdMaster = rti.getRecordTypeId();
+            }
+            //  Populate the map for DeveloperName to RecordTypeId
+            if (rti.getDeveloperName() != 'Master') {   //  Don't need as this isn't returned when using SOQL
+                this.mapRecordTypeNameToId.put(rti.getDeveloperName(), rti.getRecordTypeId());
+            }
+        }
+    }
+
+
+    /*  ****************************************  */
+    /*             Public Functions               */
+    /*  ****************************************  */
+
+    /**
+     * Creates a query string for lookup fields on the current object
+     * @param   String. The field related to the sobject lookup to create a query string for
+     *                  - If it is a standard lookup, then the field name will end with 'Id'
+     *                  - If it is a custom lookup, then the field name will end with '__c'
+     * @return  String. The query string for the SObject
+     */
+    public String createQueryStringForRelatedSObject(String passedSObjFieldName) {
+        //  Handle if the sobject lookup doesn't exist
+        if (!this.mapFieldNameToSObjectType.containsKey(passedSObjFieldName)) {
+            return '';
+        }
+
+        String sObjectName = this.mapFieldNameToSObjectType.get(passedSObjFieldName);
+        String queryString = '';
+        for (String fieldName : this.mapRelatedSObjectFields.get(sObjectName)) {
+            queryString += passedSObjFieldName.replace('__c', '__r').removeEndIgnoreCase('id') + '.' + fieldName.capitalize() + ',';
+        }
+        return queryString.removeEnd(',');
+    }
+
+
+    /**
+     * Same as above, but accepts Set<String>
+     */
+    public String createQueryStringForRelatedSObjects(Set<String> sObjectNames) {
+        String queryString = '';
+        for (String sObj : sObjectNames) {
+            queryString += this.createQueryStringForRelatedSObject(sObj) + ',';
+        }
+        return queryString.removeEnd(',');
+    }
+
+
+    /**
+     * Same as above, but accepts List<String>
+     */
+    public String createQueryStringForRelatedSObjects(List<String> sObjectNames) {
+        Set<String> setSObjectNames = new Set<String>();
+        setSObjectNames.addAll(sObjectNames);
+        return this.createQueryStringForRelatedSObjects(setSObjectNames);
+    }
+
+
+    /**
+     * Returns the default record type Id for the user. If none is found,
+     * returns the Master record type Id. Returns null if both aren't populated
+     * @return  Id. The record type Id
+     */
+    public Id getDefaultRecordTypeId() {
+        if (this.recordTypeIdDefault != null) {
+            return this.recordTypeIdDefault;
+        } else if (this.recordTypeIdMaster != null) {
+            return this.recordTypeIdMaster;
+        }
+        //  I don't really expect this to ever happen, just a catch-all
+        return null;
     }
 
 
@@ -169,5 +312,4 @@ public with sharing class SObjectUtil {
     public static Boolean orgUsesPersonAccounts() {
         return Schema.SObjectType.Account.fields.getMap().containsKey('isPersonAccount');
     }
-
 }

--- a/classes/SObjectUtilTest.cls
+++ b/classes/SObjectUtilTest.cls
@@ -23,7 +23,7 @@
  */
 @isTest
 private class SObjectUtilTest {
-    private static Set<String> PREFERRED_SOBJECTS = new Set<String>{'Account', 'Contact', 'Case', 'Lead', 'Opportunity', 'Order', 'Product2', 'Quote'};
+    static Set<String> PREFERRED_SOBJECTS = new Set<String>{'Account', 'Contact', 'Case', 'Lead', 'Opportunity', 'Order', 'Product2', 'Quote'};
 
     /*  ****************************************  */
     /*            Unit Test Functions             */
@@ -197,8 +197,6 @@ private class SObjectUtilTest {
                 System.assert(testSObjUtil.mapRecordTypeNameToId.keySet().contains(rt.Name));
                 System.assertEquals(rt.Id, testSObjUtil.mapRecordTypeNameToId.get(rt.Name));
             }
-    
-
 
         } else {
             //  Can't really be tested if no objects have Record Types set up
@@ -262,6 +260,34 @@ private class SObjectUtilTest {
 
 
     /**
+     * Tests the select all string functions for other lookups on the object
+     * Using Contract as the SObject as there are fields that need to be filtered out
+     * and are stored in the map: evilObjectFieldNames
+     */
+    @isTest
+    static void testSelectAllStringRelatedObject() {
+        String sObjectNameToTest = 'Contract';
+        SObjectUtil contractUtil = new SOBjectUtil(sObjectNameToTest);
+
+        //  We know that by default the address fields that are queried using Schema.SObjectType.getDescribe()
+        //  have both billing and shipping fields, however you may not be able to query the shipping fields
+        System.assertNotEquals(null, contractUtil.selectAllString);
+        System.assert(contractUtil.selectAllString.containsIgnoreCase('billingaddress'));
+        System.assert(!contractUtil.selectAllString.containsIgnoreCase('ShippingAddress'));
+
+        //  Next we want to make sure that we can get the fields for a lookup on Contract
+        //  Account should be a default lookup field on Contract, but we need to use AccountId
+        //  for the field name
+        String accountLookupQueryString = contractUtil.createQueryStringForRelatedSObject('AccountId');
+        System.assertNotEquals(null, accountLookupQueryString);
+
+        Set<String> setObjects = new Set<String>{'AccountId', 'OwnerId'};
+        List<String> listObjects = new List<String>{'AccountId', 'OwnerId'};
+        System.assertEquals(contractUtil.createQueryStringForRelatedSObjects(setObjects), contractUtil.createQueryStringForRelatedSObjects(listObjects));
+    }
+
+
+    /**
      * Tests that the required fields set is populated, all all fields in the set are
      * also listed as keys in SObjectUtil.mapDevNameToType. Using the Account SObject
      * at a minimum the following fields are required: Id, Name, OwnerId, CreatedById,
@@ -287,6 +313,28 @@ private class SObjectUtilTest {
         System.assertEquals(expectedRequiredFields, countedExistingFields);
     }
 
+
+    /**
+     * Tests the query string for lookup fields on a standard SObject
+     */
+    @isTest
+    static void testLookupQueryStringPopulate() {
+        //  Setup
+        SObjectUtil contractUtil = new SObjectUtil('Contract');
+        String sObjectNameFail = 'Account';
+        String sObjectNamePass = 'AccountId';
+
+        //  Test
+        String returnStringFail = contractUtil.createQueryStringForRelatedSObject(sObjectNameFail);
+        String returnStringPass = contractUtil.createQueryStringForRelatedSObject(sObjectnamePass);
+
+        //  Assert
+        System.assertEquals('', returnStringFail);
+        System.assert(returnStringPass.length() > 0);
+        System.assert(returnStringPass.contains(sObjectNamePass.removeEndIgnoreCase('Id')));
+    }
+
+
     /**
      * This is a hard one to successfully test as it depends on whether or not the object
      * in the org has any fields that are marked as unique
@@ -309,6 +357,24 @@ private class SObjectUtilTest {
     }
 
 
+    /**
+     * Tests to make sure the correct record type Id fields are being populated
+     */
+    @isTest
+    static void testGetDefaultRecordTypeId() {
+        SObjectUtil accountUtil = new SObjectUtil('Account');
+        SObjectUtil contactUtil = new SObjectUtil('Contact');
+
+        System.assertNotEquals(null, accountUtil.getDefaultRecordTypeId());
+        System.assertNotEquals(null, accountUtil.recordTypeIdDefault);
+        System.assertNotEquals(null, accountUtil.recordTypeIdMaster);
+
+        System.assertNotEquals(null, contactUtil.getDefaultRecordTypeId());
+        System.assertNotEquals(null, contactUtil.recordTypeIdDefault);
+        System.assertNotEquals(null, contactUtil.recordTypeIdMaster);
+    }
+
+
     /*  ****************************************  */
     /*             Private Functions              */
     /*  ****************************************  */
@@ -328,5 +394,4 @@ private class SObjectUtilTest {
         }
         return sObjectsWithRts;
     }
-
 }


### PR DESCRIPTION
About
====

Previously an SObject's record type was retrieved using a SOQL query.  This branch updates that to use the `Schema` object to populate the record types.  Using this method also allows us to find what the default record type is for the user, and reduces the number of SOQL queries made during setup by one.

New Var(s)
-----------
- Public Id: recordTypeIdDefault
The user's default record type Id for the SObject

- Public Id: recordTypeIdMaster
The master record type Id for the SObject

New Function(s)
------------------
- Private: populateRecordTypeInformation()
Populates record type information
- Public: testGetDefaultRecordTypeId()
Returns the default record type Id for the user for the object.  If none is found, use the master Id, otherwise return `null`

Unit Tests
-----------
- Added new unit test for testing the query string for a lookup sobject
- Added new unit test for testing if the correct data is returned when running `getDefaultRecordTypeId()`

Fixes
------
- Fixed an issue where when using `createQueryStringForRelatedSObject` for a standard lookup, the correct string would not be returned.